### PR TITLE
#26 Implemented text height calculation using NSMutableAttributedString.

### DIFF
--- a/Source/Private/Helpers/String+Truncation.swift
+++ b/Source/Private/Helpers/String+Truncation.swift
@@ -32,11 +32,15 @@ extension String {
                         attributes: [NSAttributedString.Key: Any],
                         trailingTextAttributes: [NSAttributedString.Key: Any]) -> NSAttributedString {
 
-        if !willFit(to: size, attributes: attributes) {
+        if !willFit(to: size,
+                    attributes: attributes,
+                    trailingTextAttributes: trailingTextAttributes) {
+
             let indexOfLastCharacterThatFits = indexThatFits(size: size,
                                                              ellipsesString: ellipsesString,
                                                              trailingText: trailingText,
                                                              attributes: attributes,
+                                                             trailingTextAttributes: trailingTextAttributes,
                                                              minIndex: 0,
                                                              maxIndex: count)
 
@@ -56,12 +60,18 @@ extension String {
     func willFit(to size: CGSize,
                  ellipsesString: String = "",
                  trailingText: String = "",
-                 attributes: [NSAttributedString.Key: Any]) -> Bool {
+                 attributes: [NSAttributedString.Key: Any],
+                 trailingTextAttributes: [NSAttributedString.Key: Any]) -> Bool {
 
-        let text = (self + ellipsesString + trailingText) as NSString
+        let attributedString = NSMutableAttributedString(string: self + ellipsesString, attributes: attributes)
+        let attributedTrailingString = NSAttributedString(string: trailingText, attributes: trailingTextAttributes)
+        attributedString.append(attributedTrailingString)
+
         let boundedSize = CGSize(width: size.width, height: .greatestFiniteMagnitude)
         let options: NSStringDrawingOptions = [.usesLineFragmentOrigin, .usesFontLeading]
-        let boundedRect = text.boundingRect(with: boundedSize, options: options, attributes: attributes, context: nil)
+        let boundedRect = attributedString.boundingRect(with: boundedSize,
+                                                        options: options,
+                                                        context: nil)
         return boundedRect.height <= size.height
     }
 
@@ -71,6 +81,7 @@ extension String {
                                ellipsesString: String,
                                trailingText: String,
                                attributes: [NSAttributedString.Key: Any],
+                               trailingTextAttributes: [NSAttributedString.Key: Any],
                                minIndex: Int,
                                maxIndex: Int) -> Int {
 
@@ -80,11 +91,17 @@ extension String {
         let range = startIndex..<index(startIndex, offsetBy: midIndex)
         let substring = String(self[range])
 
-        if !substring.willFit(to: size, ellipsesString: ellipsesString, trailingText: trailingText, attributes: attributes) {
+        if !substring.willFit(to: size,
+                              ellipsesString: ellipsesString,
+                              trailingText: trailingText,
+                              attributes: attributes,
+                              trailingTextAttributes: trailingTextAttributes) {
+
             return indexThatFits(size: size,
                                  ellipsesString: ellipsesString,
                                  trailingText: trailingText,
                                  attributes: attributes,
+                                 trailingTextAttributes: trailingTextAttributes,
                                  minIndex: minIndex,
                                  maxIndex: midIndex)
         }
@@ -93,6 +110,7 @@ extension String {
                                  ellipsesString: ellipsesString,
                                  trailingText: trailingText,
                                  attributes: attributes,
+                                 trailingTextAttributes: trailingTextAttributes,
                                  minIndex: midIndex,
                                  maxIndex: maxIndex)
 

--- a/Source/Private/Helpers/String+Truncation.swift
+++ b/Source/Private/Helpers/String+Truncation.swift
@@ -62,7 +62,7 @@ extension String {
                  trailingText: String = "",
                  attributes: [NSAttributedString.Key: Any],
                  trailingTextAttributes: [NSAttributedString.Key: Any]) -> Bool {
-        
+
         var trailingTextAttributes = trailingTextAttributes
         if let textFont = attributes[.font] as? UIFont,
            let trailingTextFont = trailingTextAttributes[.font] as? UIFont,

--- a/Source/Private/Helpers/String+Truncation.swift
+++ b/Source/Private/Helpers/String+Truncation.swift
@@ -62,6 +62,13 @@ extension String {
                  trailingText: String = "",
                  attributes: [NSAttributedString.Key: Any],
                  trailingTextAttributes: [NSAttributedString.Key: Any]) -> Bool {
+        
+        var trailingTextAttributes = trailingTextAttributes
+        if let textFont = attributes[.font] as? UIFont,
+           let trailingTextFont = trailingTextAttributes[.font] as? UIFont,
+           trailingTextFont.lineHeight < textFont.lineHeight {
+            trailingTextAttributes[.font] = textFont
+        }
 
         let attributedString = NSMutableAttributedString(string: self + ellipsesString, attributes: attributes)
         let attributedTrailingString = NSAttributedString(string: trailingText, attributes: trailingTextAttributes)

--- a/Source/Private/Helpers/String+Truncation.swift
+++ b/Source/Private/Helpers/String+Truncation.swift
@@ -33,6 +33,8 @@ extension String {
                         trailingTextAttributes: [NSAttributedString.Key: Any]) -> NSAttributedString {
 
         if !willFit(to: size,
+                    ellipsesString: ellipsesString,
+                    trailingText: trailingText,
                     attributes: attributes,
                     trailingTextAttributes: trailingTextAttributes) {
 

--- a/Source/Private/Helpers/String+Truncation.swift
+++ b/Source/Private/Helpers/String+Truncation.swift
@@ -33,8 +33,6 @@ extension String {
                         trailingTextAttributes: [NSAttributedString.Key: Any]) -> NSAttributedString {
 
         if !willFit(to: size,
-                    ellipsesString: ellipsesString,
-                    trailingText: trailingText,
                     attributes: attributes,
                     trailingTextAttributes: trailingTextAttributes) {
 

--- a/Source/Public/Views/TvOSMoreButton.swift
+++ b/Source/Public/Views/TvOSMoreButton.swift
@@ -264,6 +264,8 @@ open class TvOSMoreButton: UIView {
                                                    attributes: textAttributes,
                                                    trailingTextAttributes: trailingTextAttributes)
         accessibilityLabel = label.attributedText?.string
-        isFocusable = !text.willFit(to: labelSize, attributes: textAttributes)
+        isFocusable = !text.willFit(to: labelSize,
+                                    attributes: textAttributes,
+                                    trailingTextAttributes: trailingTextAttributes)
     }
 }


### PR DESCRIPTION
Text and trailing text have different attributes, so you need to use NSMutableAttributedString to calculate the height.